### PR TITLE
Poms clean up

### DIFF
--- a/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/pom.xml
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>craftbukkit</artifactId>
-			<version>1.10-R0.1-SNAPSHOT</version>
+			<version>1.10.2-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/pom.xml
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>craftbukkit</artifactId>
-			<version>1.11.2-R0.1-SNAPSHOT</version>
+			<version>1.11-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R3/pom.xml
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R3/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>craftbukkit</artifactId>
-			<version>1.8.4-R0.1-SNAPSHOT</version>
+			<version>1.8.8-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/NCPCompatNonFree/pom.xml
+++ b/NCPCompatNonFree/pom.xml
@@ -29,7 +29,7 @@ The NCPPlugin sub-project contains the relevant factories (MCAccessFactory, Enti
 			<id>all</id>
 
 			<modules>
-				<module>NCPCompatCB2512</module>
+				<!-- <module>NCPCompatCB2512</module>
 				<module>NCPCompatCB2545</module>
 				<module>NCPCompatCB2602</module>
 				<module>NCPCompatCB2645</module>
@@ -37,7 +37,7 @@ The NCPPlugin sub-project contains the relevant factories (MCAccessFactory, Enti
 				<module>NCPCompatCB2763</module>
 				<module>NCPCompatCB2794</module>
 				<module>NCPCompatCB2808</module>
-				<module>NCPCompatCB2882</module>
+				<module>NCPCompatCB2882</module> -->
 				<module>NCPCompatCB2922</module>
 				<module>NCPCompatCB3026</module>
 				<module>NCPCompatCB3043</module>

--- a/NCPCompatNonFree/pom.xml
+++ b/NCPCompatNonFree/pom.xml
@@ -115,7 +115,7 @@ The NCPPlugin sub-project contains the relevant factories (MCAccessFactory, Enti
 					<artifactId>ncpcompatcb2922</artifactId>
 					<version>1.1-SNAPSHOT</version>
 				</dependency>
-				<dependency>
+				<!-- <dependency>
 					<groupId>fr.neatmonster</groupId>
 					<artifactId>ncpcompatcb2882</artifactId>
 					<version>1.1-SNAPSHOT</version>
@@ -159,7 +159,7 @@ The NCPPlugin sub-project contains the relevant factories (MCAccessFactory, Enti
 					<groupId>fr.neatmonster</groupId>
 					<artifactId>ncpcompatcb2512</artifactId>
 					<version>1.1-SNAPSHOT</version>
-				</dependency>
+				</dependency> -->
 			</dependencies>
 		</profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
 			<id>bukkit</id>
 			<url>http://repo.bukkit.org/content/groups/public/</url>
 		</repository>
+		<repository>
+    			<id>nms-repo</id>
+    			<url>https://repo.codemc.org/repository/nms/</url>
+		</repository>
 	</repositories>
 
 	<description>The initial pom design had been taken from mbax (GitHub).

--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,11 @@
 		</repository>
 		<!-- <repository> <id>md_5-releases</id> <url>http://repo.md-5.net/content/repositories/releases/</url> 
 			</repository> <repository> <id>md_5-snapshots</id> <url>http://repo.md-5.net/content/repositories/snapshots/</url> 
-			</repository> -->
+			</repository>
 		<repository>
 			<id>bukkit</id>
 			<url>http://repo.bukkit.org/content/groups/public/</url>
-		</repository>
+		</repository> -->
 		<repository>
     			<id>nms-repo</id>
     			<url>https://repo.codemc.org/repository/nms/</url>


### PR DESCRIPTION
Can now build NCP 1.7-1.14.4 normally with the command:
mvn clean package install -P nonfree_build -P nonfree_include -P all

Sadly, nowhere still contains craftbukkit 1.6.1/1.6.4/1.6.5 use for building the older CB